### PR TITLE
Develop (#326)

### DIFF
--- a/ex/auto/writer/README.md
+++ b/ex/auto/writer/README.md
@@ -2,9 +2,9 @@
 
 Welcome to Writer Automation folder. Open a sub folder to get to an example.
 
-- [hello_save](./odev_hello_save/) - example creates a new text document, containing two short paragraphs, and saves
-- [hello_world](./hello_world/) - Simple Hello World example using [ScriptForge].
-- [odev_build_doc](./odev_build_doc/) - example creates a new Writer document, add a few lines, styles, images, text frame, bookmark.
+- [hello_save](./odev_hello_save/) - A barebones example that creates a new Writer document, enters two short paragraphs, and saves it.
+- [hello_world](./hello_world/) - Simple Hello World example using [ScriptForge]. NOTE: Skip this unless you are already familiar with ScriptForge and know that you need it.
+- [odev_build_doc](./odev_build_doc/) - A more elaborate example that creates a new Writer document that incorporates styles, images, a text frame (text box), and bookmarks.
 - [odev_build_form](./odev_build_form/) - example shows how to build a form using [OOO Development Tools].
 - [odev_build_form2](./odev_build_form2/) - example shows how to build a form using [OOO Development Tools] using controls.
 - [odev_doc_print_console](./odev_doc_print_console/) - example shows how to print the contents of a Writer document to the console.

--- a/ex/auto/writer/hello_world/README.md
+++ b/ex/auto/writer/hello_world/README.md
@@ -2,6 +2,9 @@
 
 This is a basic example that opens up a new Writer document and writes *Hello World* using [ScriptForge](https://gitlab.com/LibreOfficiant/scriptforge)
 and [ScriptForge Typings](https://pypi.org/project/types-scriptforge/).
+ScriptForge is a repository of "macro scripting resources" that are written in basic, but callable from python. They have been contributed for consideration to be incorporated in future distributions of LibreOffice (hence the "forge" aspect of the name.) In the mean time, we can access them explicitly via the scriptforge PyPI package. See https://gitlab.com/LibreOfficiant/scriptforge.
+
+NOTE: This is not a real-world example of why you would want to invoke any of the ScriptForge resources. It merely illustrates how you would go about it should you decide that it is useful to you.
 
 See [source code](./start.py)
 

--- a/ex/auto/writer/hello_world/start.py
+++ b/ex/auto/writer/hello_world/start.py
@@ -4,7 +4,7 @@ This module is not to be called directly
 and is intended to be called from the projects main.
 Such as: python -m main auto --process "ex/auto/writer/hello_world/start.py"
 """
-from __future__ import annotations
+from __future__ import annotations  # supports the `if TYPE_CHECKING:` block, below
 from pathlib import Path
 import os
 import sys
@@ -14,9 +14,10 @@ from ooo.dyn.beans.property_value import PropertyValue
 
 # region Inject Project root into path
 
-# This section is only useed to insert this projects root into
-# python sys path for the purpose of using part of this projects
-# build in librairies.
+# This section is only useed to insert this project's root into
+# python sys path for the purpose of using part of this project's
+# build in libraries.
+
 
 def register_proj_path() -> None:
     def get_root_path(pth) -> Path:
@@ -33,7 +34,7 @@ def register_proj_path() -> None:
     ps = os.environ.get("project_root", None)
     if ps is None:
         ps = str(get_root_path(Path(__file__).absolute()))
-    if not ps in sys.path:
+    if ps not in sys.path:
         sys.path.insert(0, ps)
 
 
@@ -44,11 +45,17 @@ register_proj_path()
 from src.lib.connect import LoSocketStart
 
 if TYPE_CHECKING:
+    # These imports are only performed at dev-time (to inform the IDE's linter)
     from com.sun.star.text import XText
     from com.sun.star.frame import DispatchHelper
 
 
 def main() -> int:
+    # FYI: The comments that follow refer to the "soffice" server.
+    # The "soffice" executable gets its name from "Star Office," the
+    # original name of the "Open Office" suite, before it was eventually
+    # forked as "Libre Office."
+
     # set the port to start soffice on
     port = 2002
     # create an instance used to launch soffice as a server
@@ -56,6 +63,13 @@ def main() -> int:
 
     # launch soffice (LibreOffice server)
     lo.connect()
+
+    # ScriptForge is a repository of "macro scripting resources" that are
+    # written in basic, but callable from python. They have been contributed
+    # for consideration to be incorporated in future distributions of
+    # LibreOffice (hence the "forge" aspect of the name.) In the mean time, we
+    # can access them explicitly via the scriptforge PyPI package. See
+    # https://gitlab.com/LibreOfficiant/scriptforge.
 
     # Connect ScriptForge to the running soffice server
     SF.ScriptForge(hostname=lo.host, port=lo.port)
@@ -71,13 +85,17 @@ def main() -> int:
     # get XText t can access to text cursor
     txt = odoc.getText()
 
-    # get document cursor
+    # get a document cursor that is pre-positioned at the end of the document's
+    # contents (i.e. both the start of the selection range and the end of the
+    # range are set to after the last character of the current contents.)
     cursor = txt.getEnd()
 
-    # write text
+    # write text -- i.e. replace the cursor's current selection with the given
+    # string. In this case, since the start of the selection and the end of the
+    # selection are the same, it's known as a "position" rather than a
+    # "selection." The given text is therefore "inserted" at the current
+    # position.
     cursor.setString("Hello World")
-
-    bas = SF.CreateScriptService("Basic")
 
     # create a dispatch helper
     dispatcher: DispatchHelper = bas.CreateUnoService(

--- a/ex/auto/writer/odev_build_doc/start.py
+++ b/ex/auto/writer/odev_build_doc/start.py
@@ -33,172 +33,64 @@ from ooodev.utils.props import Props
 
 
 def main() -> int:
-    delay = 2_000  # delay so users can see changes.
-    im_fnm = Path(__file__).parent / "data" / "skinner.png"
+    # There are unnecessary delays throughout this code, just to better
+    # illustrate this example in action.
+    # (Underscores are allowed in numeric literals since Python 3.6.)
+    delay = 2_000  # each delay, in ms
 
+    image_filename = Path(__file__).parent / "data" / "skinner.png"
+
+    # Normally, we'd use a `with ... as loader:` block here rather than a
+    # `try ... except` block to ensure that `Lo.close_office()` gets called
+    # automatically, but in this case we will offer the user the option of
+    # keeping the document open in the LibreOffice app for further editing
+    # after the completion of this script.
     loader = Lo.load_office(Lo.ConnectSocket())
     try:
         doc = WriteDoc.create_doc(loader=loader, visible=True)
-
         cursor = doc.get_cursor()
+        # Uncomment this to dump the cursor's properties to the console
+        # Props.show_obj_props(prop_kind="Cursor", obj=cursor.component)
 
-        Props.show_obj_props(prop_kind="Cursor", obj=cursor.component)
-        cursor.append("Some examples of simple text ")
+        # --------------------------------------------------------------------
+        #                               First, a few straight-forward examples
+        sample_paragraphs(cursor)
+        sample_h1(cursor, "A Nice Big Heading")
+        sample_lists(cursor)
+        sample_bookmark(cursor, bookmark_name="ad-bookmark")
+        sample_hyperlink(cursor)
+        sample_text_conditional_on_theme(cursor)
+        sample_horizontal_rule(doc, cursor)
 
-        cursor.append_line(text="styles.", styles=[Font(b=True)])
-
-        cursor.append_para(
-            text="This line is written in red italics.",
-            styles=[Font(color=CommonColor.DARK_RED).bold.italic],
-        )
-
-        cursor.append_para("Back to old style")
-        cursor.append_line()
-        cursor.append_para(text="A Nice Big Heading", styles=[ParaStyle().h1])
-        cursor.append_para("The following points are important:")
-
-        list_style = ListStyle(list_style=StyleListKind.NUM_123, num_start=-2)
-        list_style.apply(cursor.component)
-
-        cursor.append_para("Have a good breakfast")
-        cursor.append_para("Have a good lunch")
-        cursor.append_para("Have a good dinner")
-
-        # Reset to default which set cursor to No List Style
-        list_style.default.apply(cursor.component)
-        cursor.end_paragraph()
-
-        cursor.append_para("Breakfast should include:")
-
-        # set cursor style to Number abc
-        list_style = ListStyle(list_style=StyleListKind.NUM_abc, num_start=-2)
-        list_style.apply(cursor.component)
-
-        cursor.append_para("Porridge")
-        cursor.append_para("Orange Juice")
-        cursor.append_para("A Cup of Tea")
-        # reset cursor number style
-        list_style.default.apply(cursor.component)
-
-        cursor.end_paragraph()
-
-        cursor.append("This line ends with a bookmark.")
-        cursor.add_bookmark("ad-bookmark")
-        cursor.append_line()
-
+        # --------------------------------------------------------------------
+        #                    A code block with a text frame to the right of it
         cursor.append_para("Here's some code:")
 
-        tvc = doc.get_view_cursor()
-        tvc.goto_range(cursor.component.getEnd(), False)
+        # We want to memorize the current vertical position, but a regular text
+        # cursor doesn't know how to give us that. So, we need to create a View
+        # Cursor and synchoronize it with the current position of the regular
+        # text cursor first.
+        text_view_cursor = doc.get_view_cursor()
+        text_view_cursor.goto_range(cursor.component.getEnd(), False)
+        y_pos_at_start_of_code_block = text_view_cursor.get_position().Y
 
-        y_pos = tvc.get_position().Y
+        sample_code_block(cursor)
 
-        cursor.end_paragraph()
-        code_font = Font(name=Info.get_font_mono_name(), size=10)
-        code_font.apply(cursor.component)
+        sample_text_frame(cursor, text_view_cursor, y_pos_at_start_of_code_block)
 
-        cursor.append_line("public class Hello")
-        cursor.append_line("{")
-        cursor.append_line("  public static void main(String args[]")
-        cursor.append_line('  {  System.out.println("Hello World");  }')
-        cursor.append_para("}  // end of Hello class")
-
-        # reset the cursor formatting
-        ParaStyle.default.apply(cursor.component)
-
-        # Format the background color of the previous paragraph.
-        bg_color = ParaBgColor(CommonColor.LIGHT_GRAY)
-        cursor.style_prev_paragraph(styles=[bg_color])
-
-        cursor.append_para("A text frame")
-
-        pg = tvc.get_current_page()
-        # add a text frame to the page and position it over the previous paragraph.
-        # custom color is added via styles
-
-        frame_color = FrameColor(CommonColor.DEFAULT_BLUE)
-        # create a border
-        bdr_sides = Sides(
-            all=Side(
-                line=BorderLineKind.SOLID, color=CommonColor.RED, width=LineSize.THIN
-            )
-        )
-
-        _ = cursor.add_text_frame(
-            text="This is a newly created text frame.\nWhich is over on the right of the page, next to the code.",
-            ypos=y_pos,
-            page_num=pg,
-            width=UnitMM(40),
-            height=UnitMM(15),
-            styles=[frame_color, bdr_sides],
-        )
-
-        # Insert a hyperlink.
-        cursor.append("A link to ")
-
-        hl = Hyperlink(
-            name="ODEV_GITHUB",
-            url="https://github.com/Amourspirit/python_ooo_dev_tools",
-            target=TargetKind.BLANK,
-        )
-        cursor.append("OOO Development Tools", styles=[hl])
-
-        cursor.append_para(" Website.")
-
-        # Add text based on theme color.
-        # Supports LibreOffice 7.5 and above.
-        if Info.version_info >= (7, 5, 0, 0):
-            cursor.append_para()
-            try:
-                gen_theme_color = ThemeGeneral()
-                if gen_theme_color.background_color < 0:
-                    # -1 is Automatic color.
-                    # assume light color
-                    dark = False
-                else:
-                    rgb = color_util.RGB.from_int(gen_theme_color.background_color)
-                    dark = rgb.is_dark()
-            except Exception:
-                dark = False
-            if dark:
-                cursor.append_para(
-                    "This text is colored to match a dark theme.",
-                    styles=[Font(color=color_util.StandardColor.BLUE_LIGHT3, size=16)],
-                )
-            else:
-                cursor.append_para(
-                    "This text is colored to match a light theme.",
-                    styles=[Font(color=color_util.StandardColor.BLUE_DARK3, size=16)],
-                )
-
+        # --------------------------------------------------------------------
+        #                                                          Some images
         # start a new page
         cursor.page_break()
 
-        # demonstrates how to lock the screen, Add content and then unlock the screen.
+        # this demonstrates how to lock the screen, add content and then unlock the screen.
         with Lo.ControllerLock():
             # Lo.delay(delay)
-            cursor.append_para(text="Image Example", styles=[ParaStyle().h2])
+            sample_h2(cursor, "Image Example")
 
-            cursor.append_para(f'The following image comes from "{im_fnm.name}":')
-            cursor.end_paragraph()
+            img_size = sample_image(image_filename, cursor)
 
-            # For unknown reason if append is called with a new line here it cause a fatal error below on line 209 (Write.end_paragraph(cursor))
-            # but only if image is add on line 208 (Write.add_image_shape(cursor=cursor, fnm=im_fnm)).
-            cursor.append("Image as a link: ")
-
-            img_size = ImagesLo.get_size_100mm(im_fnm=im_fnm)
-            cursor.add_image_link(
-                fnm=im_fnm,
-                width=img_size.width,
-                height=img_size.height,
-            )
-
-            # enlarge by 1.5x
-            h = round(img_size.height * 1.5)
-            w = round(img_size.width * 1.5)
-
-            cursor.add_image_link(fnm=im_fnm, width=w, height=h)
-            cursor.end_paragraph()
+            sample_image_enlarged(image_filename, cursor, img_size, enlargement_factor=1.5)
 
         Lo.delay(delay)
 
@@ -212,39 +104,24 @@ def main() -> int:
             #   Fatal Python error: Aborted
             # on windows is fine. Running on linux in headless fine.
 
-            cursor.append_line("Image as a shape: ")
-            # add image as shape to page
-            cursor.add_image_shape(fnm=im_fnm)
-            cursor.end_paragraph()
+            sample_image_as_shape(image_filename, cursor)
             Lo.delay(delay)
 
-        text_width = doc.get_page_text_width()
+        # --------------------------------------------------------------------
+        #                                               Some metadata examples
+        sample_horizontal_rule(doc, cursor)
 
-        cursor.add_line_divider(line_width=round(text_width * 0.5))
+        sample_datetime_insertions(cursor)
 
-        # append timestamp as LO Fields.
-        cursor.append_para("\nTimestamp: " + DateUtil.time_stamp() + "\n")
-        cursor.append("Time (according to office): ")
-        cursor.append_date_time()
-        cursor.end_paragraph()
+        set_some_document_properties(doc, cursor)
 
-        # set some of the document properties.
-        Info.set_doc_props(
-            doc=doc.component,
-            subject="Writer Text Example",
-            title="Examples",
-            author=":Barry-Thomas-Paul: Moss",
-        )
+        # --------------------------------------------------------------------
+        #                                          Return to previous bookmark
         Lo.delay(delay)
+        return_to_previous_bookmark(doc, bookmark_name="ad-bookmark")
 
-        # move view cursor to bookmark position
-        bookmark = doc.find_bookmark("ad-bookmark")
-        assert bookmark is not None
-        bm_range = bookmark.get_anchor()
-
-        view_cursor = doc.get_view_cursor()
-        view_cursor.goto_range(bm_range, False)
-
+        # --------------------------------------------------------------------
+        #                                               Converse with the User
         Lo.delay(delay)
         msg_result = doc.msgbox(
             "Do you wish to save document?",
@@ -253,9 +130,10 @@ def main() -> int:
             buttons=MessageBoxButtonsEnum.BUTTONS_YES_NO,
         )
         if msg_result == MessageBoxResultsEnum.YES:
-            pth = Path.cwd() / "tmp"
-            pth.mkdir(parents=True, exist_ok=True)
-            doc.save_doc(pth / "build.odt")
+            destination_folder = Path.cwd() / "tmp"
+            destination_folder.mkdir(parents=True, exist_ok=True)
+            doc.save_doc(destination_folder / "build.odt")
+            print(f'Saved as {destination_folder}/build.odt')
 
         msg_result = doc.msgbox(
             "Do you wish to close document?",
@@ -267,12 +145,233 @@ def main() -> int:
             doc.close_doc()
             Lo.close_office()
         else:
-            print("Keeping document open")
+            print("Keeping document open; therefore not calling Lo.close_office()")
     except Exception:
         Lo.close_office()
         raise
 
     return 0
+
+
+# ############################################################################
+#                                 THE SAMPLES
+# ############################################################################
+
+
+def sample_paragraphs(cursor):
+    cursor.append("Some examples of simple text ")
+
+    cursor.append_line(text="styles.", styles=[Font(b=True)])
+
+    cursor.append_para(
+        text="This line is written in red italics.",
+        styles=[Font(color=CommonColor.DARK_RED).bold.italic],
+    )
+
+    cursor.append_para("Back to old style")
+    cursor.append_line()
+
+
+def sample_h1(cursor, text):
+    cursor.append_para(text, styles=[ParaStyle().h1])
+
+
+def sample_h2(cursor, text):
+    cursor.append_para(text, styles=[ParaStyle().h2])
+
+
+def sample_lists(cursor):
+    cursor.append_para("The following points are important:")
+
+    list_style = ListStyle(list_style=StyleListKind.NUM_123, num_start=-2)
+    list_style.apply(cursor.component)
+
+    cursor.append_para("Have a good breakfast")
+    cursor.append_para("Have a good lunch")
+    cursor.append_para("Have a good dinner")
+
+    # Reset to default which set cursor to No List Style
+    list_style.default.apply(cursor.component)
+    cursor.end_paragraph()
+
+    cursor.append_para("Breakfast should include:")
+
+    # set cursor style to Number abc
+    list_style = ListStyle(list_style=StyleListKind.NUM_abc, num_start=-2)
+    list_style.apply(cursor.component)
+
+    cursor.append_para("Porridge")
+    cursor.append_para("Orange Juice")
+    cursor.append_para("A Cup of Tea")
+    # reset cursor number style
+    list_style.default.apply(cursor.component)
+
+    # TODO what's the difference bewteen cursor.end_paragraph() and cursor.append_line()?
+    cursor.end_paragraph()
+
+
+def sample_bookmark(cursor, bookmark_name):
+    cursor.append("This line ends with a bookmark.")
+    cursor.add_bookmark(bookmark_name)
+    cursor.append_line()
+
+
+def sample_code_block(cursor):
+    cursor.end_paragraph()  # insert newline
+    code_font = Font(name=Info.get_font_mono_name(), size=10)
+    code_font.apply(cursor.component)
+
+    cursor.append_line("public class Hello")
+    cursor.append_line("{")
+    cursor.append_line("  public static void main(String args[]")
+    cursor.append_line('  {  System.out.println("Hello World");  }')
+    cursor.append_para("}  // end of Hello class")
+
+    # reset the cursor formatting
+    ParaStyle.default.apply(cursor.component)
+
+    # Format the background color of the previous paragraph.
+    bg_color = ParaBgColor(CommonColor.LIGHT_GRAY)
+    cursor.style_prev_paragraph(styles=[bg_color])
+
+
+def sample_text_frame(cursor, text_view_cursor, y_pos_at_start_of_code_block):
+    cursor.append_para("A text frame")
+
+    pg = text_view_cursor.get_current_page()
+    # add a text frame to the page and position it over the previous paragraph.
+    # custom color is added via styles
+
+    frame_color = FrameColor(CommonColor.DEFAULT_BLUE)
+    # create a border
+    bdr_sides = Sides(
+        all=Side(
+            line=BorderLineKind.SOLID, color=CommonColor.RED, width=LineSize.THIN
+        )
+    )
+
+    _ = cursor.add_text_frame(
+        text="This is a newly created text frame.\nWhich is over on the right of the page, next to the code.",
+        ypos=y_pos_at_start_of_code_block,
+        page_num=pg,
+        width=UnitMM(40),
+        height=UnitMM(15),
+        styles=[frame_color, bdr_sides],
+    )
+
+
+def sample_hyperlink(cursor):
+    cursor.append("A link to ")
+
+    hl = Hyperlink(
+        name="ODEV_GITHUB",
+        url="https://github.com/Amourspirit/python_ooo_dev_tools",
+        target=TargetKind.BLANK,
+    )
+    cursor.append("OOO Development Tools", styles=[hl])
+
+    cursor.append_para(" Website.")
+
+
+def sample_text_conditional_on_theme(cursor):
+    # This only works in LibreOffice 7.5 and above.
+    if Info.version_info < (7, 5, 0, 0):
+        return
+
+    cursor.append_para()
+    try:
+        gen_theme_color = ThemeGeneral()
+        if gen_theme_color.background_color < 0:
+            # -1 is Automatic color.
+            # assume light color
+            dark = False
+        else:
+            rgb = color_util.RGB.from_int(gen_theme_color.background_color)
+            dark = rgb.is_dark()
+    except Exception:
+        dark = False
+    if dark:
+        cursor.append_para(
+            "This text is colored to match a dark theme.",
+            styles=[Font(color=color_util.StandardColor.BLUE_LIGHT3, size=16)],
+        )
+    else:
+        cursor.append_para(
+            "This text is colored to match a light theme.",
+            styles=[Font(color=color_util.StandardColor.BLUE_DARK3, size=16)],
+        )
+
+
+def sample_image(image_filename, cursor):
+    cursor.append_para(f'The following image comes from "{image_filename.name}":')
+    cursor.end_paragraph()
+
+    # For unknown reason if append is called with a new line here it cause a fatal error below on line 209 (Write.end_paragraph(cursor))
+    # but only if image is add on line 208 (Write.add_image_shape(cursor=cursor, fnm=im_fnm)).
+    cursor.append("Image as a link: ")
+
+    img_size = ImagesLo.get_size_100mm(im_fnm=image_filename)
+    cursor.add_image_link(
+        fnm=image_filename,
+        width=img_size.width,
+        height=img_size.height,
+    )
+
+    return img_size
+
+
+def sample_image_enlarged(image_filename, cursor, img_size, enlargement_factor=1.5):
+    h = round(img_size.height * enlargement_factor)
+    w = round(img_size.width * enlargement_factor)
+
+    cursor.add_image_link(fnm=image_filename, width=w, height=h)
+    cursor.end_paragraph()
+
+
+def sample_image_as_shape(image_filename, cursor):
+    cursor.append_line("Image as a shape: ")
+    # add image as shape to page
+    cursor.add_image_shape(fnm=image_filename)
+    cursor.end_paragraph()
+
+
+def sample_horizontal_rule(doc, cursor):
+    text_width = doc.get_page_text_width()
+    
+    cursor.add_line_divider(line_width=round(text_width * 0.5))
+
+
+def sample_datetime_insertions(cursor):
+    # append a timestamp as text (static)
+    cursor.append_para("\nTimestamp: " + DateUtil.time_stamp() + "\n")
+    # append a timestamp as a LO Field (dynamic)
+    cursor.append("Time (according to office): ")
+    cursor.append_date_time()
+    cursor.end_paragraph()
+
+
+def set_some_document_properties(doc, cursor):
+    # Convenience method for setting the three most common document prperties
+    Info.set_doc_props(
+        doc=doc.component,
+        subject="Writer Text Example",
+        title="Examples",
+        author=":Barry-Thomas-Paul: Moss",
+    )
+    cursor.append_para("Three of the document's properties (title, subject, and author) have just been set.")
+    # NOTE: Be careful that you pass in doc.component here, not just doc (even though the argument name is just doc).
+    Info.print_doc_properties(doc.component)
+    cursor.append_para("The document's properties have been dumped to the console for your inspection. "
+                       "You can also inspect them via the operating system's file explorer.")
+
+
+def return_to_previous_bookmark(doc, bookmark_name):
+    bookmark = doc.find_bookmark(bookmark_name)
+    assert bookmark is not None
+    bm_range = bookmark.get_anchor()
+
+    view_cursor = doc.get_view_cursor()
+    view_cursor.goto_range(bm_range, False)
 
 
 if __name__ == "__main__":

--- a/ex/auto/writer/odev_hello_save/start.py
+++ b/ex/auto/writer/odev_hello_save/start.py
@@ -1,24 +1,27 @@
-from __future__ import annotations
 from pathlib import Path
 from ooodev.loader import Lo
 from ooodev.write import WriteDoc, ZoomKind
 
 
 def main() -> int:
-    # see: https://python-ooo-dev-tools.readthedocs.io/en/latest/src/utils/lo.html#ooodev.utils.lo.Lo.Loader
+    # see: https://python-ooo-dev-tools.readthedocs.io/en/latest/src/loader/lo.html#ooodev.loader.Lo.Loader
     with Lo.Loader(Lo.ConnectSocket()) as loader:
         doc = WriteDoc.create_doc(loader=loader, visible=True)
 
+        # These delays are unnecessary. They are here merely to better
+        # illustrate this example in action.
         Lo.delay(300)  # small delay before dispatching zoom command
         doc.zoom(ZoomKind.PAGE_WIDTH)
 
         cursor = doc.get_cursor()
         cursor.goto_end()  # make sure at end of doc before appending
         cursor.append_para(text="Hello LibreOffice.\n")
-        Lo.delay(1_000)  # Slow things down so user can see
+        # (Underscores are allowed in numeric literals since Python 3.6)
+        Lo.delay(1_000)
 
         cursor.append_para(text="How are you?")
         Lo.delay(2_000)
+
         tmp = Path.cwd() / "tmp"
         tmp.mkdir(exist_ok=True, parents=True)
         doc.save_doc(fnm=tmp / "hello.odt")


### PR DESCRIPTION
* updated dialog grid to compile as single script

* update radio groupbox2 for single script compile

* Improved commentary for the first three examples under auto/writer. Most importantly, deemphasized the significance of the second one (hello_world) which mysteriously brings in the ScriptForge library without any explanation of what the library is or why you would want to use it. Removed the unused "from __future__ import annotations" from odev_hello_save as it is a confounding way to start the example. Broke up the 250-line main() code in odev_build_doc/start.py into a dozen sub-functions and added copious comments throughout.

---------